### PR TITLE
docs(wording): reverse order of `automatically` and `generate`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ public class HandleData
 ```
 can be converted via the right-click context menu,
 ![ser-cs][jb-1-sercs]
-to generate automatically this JSON snippet:
+to automatically generate this JSON snippet:
 ```json
 {
   "strength": 0.0,


### PR DESCRIPTION
Sounds better this way.